### PR TITLE
Rhombus death spawns 3 Triangles; placement and temporary invulnerability

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2060,11 +2060,22 @@
             }
 
             spawnTrianglesAt(x, y, count = 3) {
+                const radius = 60;
+                const minSeparation = ENEMY_TYPES.triangle.size * 1.5;
+                const points = [];
                 for (let i = 0; i < count; i++) {
-                    const offsetAngle = Math.random() * Math.PI * 2;
-                    const offsetDist = Math.random() * 10;
-                    const spawnX = Math.max(ENEMY_TYPES.triangle.size, Math.min(this.canvas.width - ENEMY_TYPES.triangle.size, x + Math.cos(offsetAngle) * offsetDist));
-                    const spawnY = Math.max(ENEMY_TYPES.triangle.size, Math.min(this.canvas.height - ENEMY_TYPES.triangle.size, y + Math.sin(offsetAngle) * offsetDist));
+                    let tries = 0;
+                    let spawnX, spawnY;
+                    do {
+                        const angle = Math.random() * Math.PI * 2;
+                        const dist = Math.random() * radius;
+                        const px = x + Math.cos(angle) * dist;
+                        const py = y + Math.sin(angle) * dist;
+                        spawnX = Math.max(ENEMY_TYPES.triangle.size, Math.min(this.canvas.width - ENEMY_TYPES.triangle.size, px));
+                        spawnY = Math.max(ENEMY_TYPES.triangle.size, Math.min(this.canvas.height - ENEMY_TYPES.triangle.size, py));
+                        tries++;
+                    } while (tries < 20 && points.some(p => Math.hypot(p.x - spawnX, p.y - spawnY) < minSeparation));
+                    points.push({ x: spawnX, y: spawnY });
                     this.enemies.push(new Enemy(spawnX, spawnY, 'triangle', ENEMY_TYPES.triangle));
                 }
             }

--- a/public/index.html
+++ b/public/index.html
@@ -1489,8 +1489,9 @@
                 this.damageFlash = 0;
                 this.lastShot = 0;
                 this.shootDelay = type === 'octagon' ? 4000 : Infinity;
-                this.lastTrailTime = 0;
-                if (type === 'rhombus') {
+                				this.lastTrailTime = 0;
+				this.tempInvulnerableUntil = 0;
+				if (type === 'rhombus') {
                     this.invulnerable = false;
                     this.lastStateChange = Date.now();
                     this.stateChangeDuration = 2500;
@@ -1565,7 +1566,8 @@
             }
 
             takeDamage(damage, effects, score, ctx, audio) {
-                if (this.type === 'rhombus' && this.invulnerable) return true;
+                const now = Date.now();
+                if ((this.type === 'triangle' && now < this.tempInvulnerableUntil) || (this.type === 'rhombus' && this.invulnerable)) return true;
                 this.health -= damage;
                 this.damageFlash = 10;
                 effects.createHitEffect(this.x, this.y);
@@ -2060,7 +2062,7 @@
             }
 
             spawnTrianglesAt(x, y, count = 3) {
-                const desiredRadius = 70;
+                const desiredRadius = 100; // will be clamped to at least 70 later; use larger to help stay outside 140px diameter while honoring bounds
                 const size = ENEMY_TYPES.triangle.size;
                 const h = size * 1.5;
                 const marginX = h * 0.8660254037844386; // half-width of triangle
@@ -2099,12 +2101,13 @@
                     }
                 }
 
-                let radius = Math.min(desiredRadius, bestAllowed);
+                // Ensure radius is at least 70 (outside 140px diameter zone)
+                let radius = Math.max(70, Math.min(desiredRadius, bestAllowed));
                 if (!isFinite(radius) || radius <= 0) {
-                    radius = Math.min(desiredRadius, size * 3);
+                    radius = 70;
                 }
                 if (bestAllowed >= minRadius) {
-                    radius = Math.max(Math.min(desiredRadius, bestAllowed), minRadius);
+                    radius = Math.max(70, Math.min(desiredRadius, bestAllowed));
                 }
 
                 const angles = [bestBase, bestBase + (Math.PI * 2 / 3), bestBase + (Math.PI * 4 / 3)];
@@ -2114,7 +2117,9 @@
                     const spawnY = y + Math.sin(ang) * radius;
                     const clampedX = Math.max(marginX, Math.min(this.canvas.width - marginX, spawnX));
                     const clampedY = Math.max(marginY, Math.min(this.canvas.height - marginY, spawnY));
-                    this.enemies.push(new Enemy(clampedX, clampedY, 'triangle', ENEMY_TYPES.triangle));
+                    const tri = new Enemy(clampedX, clampedY, 'triangle', ENEMY_TYPES.triangle);
+                    tri.tempInvulnerableUntil = Date.now() + 1500;
+                    this.enemies.push(tri);
                 }
             }
 
@@ -2218,7 +2223,8 @@
                             const bullet = this.bullets[j];
                             const bulletDist = Math.sqrt((bullet.x - enemy.x) ** 2 + (bullet.y - enemy.y) ** 2);
                             if (bulletDist < bullet.radius + enemy.radius) {
-                                if (enemy.type === 'rhombus' && enemy.invulnerable) continue;
+                                const now = Date.now();
+                                if ((enemy.type === 'rhombus' && enemy.invulnerable) || (enemy.type === 'triangle' && now < enemy.tempInvulnerableUntil)) continue;
                                 this.bullets.splice(j, 1);
                                 if (!enemy.takeDamage(50, this.effects, this.score, this.ctx, this.audio)) {
                                     this.effects.createExplosion(enemy.x, enemy.y, enemy.type, enemy.radius);
@@ -2235,17 +2241,20 @@
                         }
                         for (let j = this.effects.effects.length - 1; j >= 0; j--) {
                             const effect = this.effects.effects[j];
-                            if (effect.type === 'railgunBeam' && effect.intersectsEnemy(enemy)) {
-                                if (enemy.type === 'rhombus' && enemy.invulnerable) continue;
-                                if (!enemy.takeDamage(effect.damage, this.effects, this.score, this.ctx, this.audio)) {
-                                    this.effects.createExplosion(enemy.x, enemy.y, enemy.type, enemy.radius);
-                                    if (enemy.type === 'rhombus') {
-                                        this.spawnTrianglesAt(enemy.x, enemy.y, 3);
+                            if (effect.type === 'railgunBeam') {
+                                const now = Date.now();
+                                if ((enemy.type === 'rhombus' && enemy.invulnerable) || (enemy.type === 'triangle' && now < enemy.tempInvulnerableUntil)) continue;
+                                if (effect.intersectsEnemy(enemy)) {
+                                    if (!enemy.takeDamage(effect.damage, this.effects, this.score, this.ctx, this.audio)) {
+                                        this.effects.createExplosion(enemy.x, enemy.y, enemy.type, enemy.radius);
+                                        if (enemy.type === 'rhombus') {
+                                            this.spawnTrianglesAt(enemy.x, enemy.y, 3);
+                                        }
+                                        this.enemies.splice(i, 1);
+                                        this.score += enemy.points;
+                                        this.enemiesKilled++;
+                                        this.uiManager.showScoreAddition(enemy.points);
                                     }
-                                    this.enemies.splice(i, 1);
-                                    this.score += enemy.points;
-                                    this.enemiesKilled++;
-                                    this.uiManager.showScoreAddition(enemy.points);
                                 }
                             }
                         }

--- a/public/index.html
+++ b/public/index.html
@@ -2059,6 +2059,16 @@
                 this.enemies.push(new Enemy(x, y, type, ENEMY_TYPES[type]));
             }
 
+            spawnTrianglesAt(x, y, count = 3) {
+                for (let i = 0; i < count; i++) {
+                    const offsetAngle = Math.random() * Math.PI * 2;
+                    const offsetDist = Math.random() * 10;
+                    const spawnX = Math.max(ENEMY_TYPES.triangle.size, Math.min(this.canvas.width - ENEMY_TYPES.triangle.size, x + Math.cos(offsetAngle) * offsetDist));
+                    const spawnY = Math.max(ENEMY_TYPES.triangle.size, Math.min(this.canvas.height - ENEMY_TYPES.triangle.size, y + Math.sin(offsetAngle) * offsetDist));
+                    this.enemies.push(new Enemy(spawnX, spawnY, 'triangle', ENEMY_TYPES.triangle));
+                }
+            }
+
             startWave(waveConfig) {
                 this.currentWave = waveConfig.wave;
                 this.waveStarted = true;
@@ -2146,6 +2156,9 @@
                     if (!this.player.isDashing && dist < enemy.radius + this.player.radius) {
                         this.effects.createExplosion(enemy.x, enemy.y, enemy.type, enemy.radius);
                         this.player.takeDamage(enemy.damage, (this.player.x + enemy.x) / 2, (this.player.y + enemy.y) / 2, this.effects, this.audio);
+                        if (enemy.type === 'rhombus') {
+                            this.spawnTrianglesAt(enemy.x, enemy.y, 3);
+                        }
                         this.enemies.splice(i, 1);
                         this.enemiesKilled++;
                         // No score addition for collision deaths
@@ -2160,6 +2173,9 @@
                                 this.bullets.splice(j, 1);
                                 if (!enemy.takeDamage(50, this.effects, this.score, this.ctx, this.audio)) {
                                     this.effects.createExplosion(enemy.x, enemy.y, enemy.type, enemy.radius);
+                                    if (enemy.type === 'rhombus') {
+                                        this.spawnTrianglesAt(enemy.x, enemy.y, 3);
+                                    }
                                     this.enemies.splice(i, 1);
                                     this.score += enemy.points;
                                     this.enemiesKilled++;
@@ -2174,6 +2190,9 @@
                                 if (enemy.type === 'rhombus' && enemy.invulnerable) continue;
                                 if (!enemy.takeDamage(effect.damage, this.effects, this.score, this.ctx, this.audio)) {
                                     this.effects.createExplosion(enemy.x, enemy.y, enemy.type, enemy.radius);
+                                    if (enemy.type === 'rhombus') {
+                                        this.spawnTrianglesAt(enemy.x, enemy.y, 3);
+                                    }
                                     this.enemies.splice(i, 1);
                                     this.score += enemy.points;
                                     this.enemiesKilled++;

--- a/public/index.html
+++ b/public/index.html
@@ -2060,23 +2060,61 @@
             }
 
             spawnTrianglesAt(x, y, count = 3) {
-                const radius = 60;
-                const minSeparation = ENEMY_TYPES.triangle.size * 1.5;
-                const points = [];
-                for (let i = 0; i < count; i++) {
-                    let tries = 0;
-                    let spawnX, spawnY;
-                    do {
-                        const angle = Math.random() * Math.PI * 2;
-                        const dist = Math.random() * radius;
-                        const px = x + Math.cos(angle) * dist;
-                        const py = y + Math.sin(angle) * dist;
-                        spawnX = Math.max(ENEMY_TYPES.triangle.size, Math.min(this.canvas.width - ENEMY_TYPES.triangle.size, px));
-                        spawnY = Math.max(ENEMY_TYPES.triangle.size, Math.min(this.canvas.height - ENEMY_TYPES.triangle.size, py));
-                        tries++;
-                    } while (tries < 20 && points.some(p => Math.hypot(p.x - spawnX, p.y - spawnY) < minSeparation));
-                    points.push({ x: spawnX, y: spawnY });
-                    this.enemies.push(new Enemy(spawnX, spawnY, 'triangle', ENEMY_TYPES.triangle));
+                const desiredRadius = 70;
+                const size = ENEMY_TYPES.triangle.size;
+                const h = size * 1.5;
+                const marginX = h * 0.8660254037844386; // half-width of triangle
+                const marginY = h; // top/bottom margin
+                const minRadius = Math.max(h + 5, size * 2);
+
+                const allowedForAngle = (angle) => {
+                    const c = Math.cos(angle);
+                    const s = Math.sin(angle);
+                    let rMaxX = Infinity;
+                    if (c > 0) rMaxX = (this.canvas.width - marginX - x) / c;
+                    else if (c < 0) rMaxX = (x - marginX) / (-c);
+                    let rMaxY = Infinity;
+                    if (s > 0) rMaxY = (this.canvas.height - marginY - y) / s;
+                    else if (s < 0) rMaxY = (y - marginY) / (-s);
+                    return Math.max(0, Math.min(rMaxX, rMaxY));
+                };
+
+                const computeAllowedForBase = (base) => {
+                    const a1 = base;
+                    const a2 = base + (Math.PI * 2 / 3);
+                    const a3 = base + (Math.PI * 4 / 3);
+                    return Math.min(allowedForAngle(a1), allowedForAngle(a2), allowedForAngle(a3));
+                };
+
+                let bestBase = 0;
+                let bestAllowed = -1;
+                const candidates = 24;
+                const offset = Math.random() * Math.PI * 2;
+                for (let k = 0; k < candidates; k++) {
+                    const base = offset + (k * (Math.PI * 2 / candidates));
+                    const allowed = computeAllowedForBase(base);
+                    if (allowed > bestAllowed) {
+                        bestAllowed = allowed;
+                        bestBase = base;
+                    }
+                }
+
+                let radius = Math.min(desiredRadius, bestAllowed);
+                if (!isFinite(radius) || radius <= 0) {
+                    radius = Math.min(desiredRadius, size * 3);
+                }
+                if (bestAllowed >= minRadius) {
+                    radius = Math.max(Math.min(desiredRadius, bestAllowed), minRadius);
+                }
+
+                const angles = [bestBase, bestBase + (Math.PI * 2 / 3), bestBase + (Math.PI * 4 / 3)];
+                for (let i = 0; i < 3; i++) {
+                    const ang = angles[i];
+                    const spawnX = x + Math.cos(ang) * radius;
+                    const spawnY = y + Math.sin(ang) * radius;
+                    const clampedX = Math.max(marginX, Math.min(this.canvas.width - marginX, spawnX));
+                    const clampedY = Math.max(marginY, Math.min(this.canvas.height - marginY, spawnY));
+                    this.enemies.push(new Enemy(clampedX, clampedY, 'triangle', ENEMY_TYPES.triangle));
                 }
             }
 


### PR DESCRIPTION
- Add triangle spawn on Rhombus death (3 spawns at 120 degrees separation)
- Ensure spawn points are outside a 140px-diameter zone (radius >= 70) around death point
- Keep all three spawns on-screen; clamp within canvas bounds
- Add 1.5s temporary invulnerability to spawned triangles; bullets/railgun respect this window
- Note: repo still references missing audio files (pause-deactivate.wav, enemy-shoot.wav)