### PR TITLE
Spawn triangles on rhombus death

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1490,6 +1490,7 @@
                 this.lastShot = 0;
                 this.shootDelay = type === 'octagon' ? 4000 : Infinity;
                 this.lastTrailTime = 0;
+                this.spawnShieldUntil = 0;
                 if (type === 'rhombus') {
                     this.invulnerable = false;
                     this.lastStateChange = Date.now();
@@ -1565,7 +1566,7 @@
             }
 
             takeDamage(damage, effects, score, ctx, audio) {
-                if (this.type === 'rhombus' && this.invulnerable) return true;
+                if ((this.spawnShieldUntil && Date.now() < this.spawnShieldUntil) || (this.type === 'rhombus' && this.invulnerable)) return true;
                 this.health -= damage;
                 this.damageFlash = 10;
                 effects.createHitEffect(this.x, this.y);
@@ -2059,6 +2060,22 @@
                 this.enemies.push(new Enemy(x, y, type, ENEMY_TYPES[type]));
             }
 
+            spawnTrianglesAround(cx, cy) {
+                const count = 3;
+                const minRadius = 70;
+                const extraRadius = 40; // spawn a bit further out for spacing
+                const now = Date.now();
+                for (let i = 0; i < count; i++) {
+                    const angle = (Math.PI * 2 * i) / count + Math.random() * 0.4; // slight randomization
+                    const distance = minRadius + extraRadius + Math.random() * 30;
+                    const x = cx + Math.cos(angle) * distance;
+                    const y = cy + Math.sin(angle) * distance;
+                    const enemy = new Enemy(x, y, 'triangle', ENEMY_TYPES['triangle']);
+                    enemy.spawnShieldUntil = now + 1500;
+                    this.enemies.push(enemy);
+                }
+            }
+
             startWave(waveConfig) {
                 this.currentWave = waveConfig.wave;
                 this.waveStarted = true;
@@ -2145,6 +2162,9 @@
                     const dist = enemy.update(this.player, this.canvas, this.effects, this.enemyBullets, this.audio);
                     if (!this.player.isDashing && dist < enemy.radius + this.player.radius) {
                         this.effects.createExplosion(enemy.x, enemy.y, enemy.type, enemy.radius);
+                        if (enemy.type === 'rhombus') {
+                            this.spawnTrianglesAround(enemy.x, enemy.y);
+                        }
                         this.player.takeDamage(enemy.damage, (this.player.x + enemy.x) / 2, (this.player.y + enemy.y) / 2, this.effects, this.audio);
                         this.enemies.splice(i, 1);
                         this.enemiesKilled++;
@@ -2156,10 +2176,13 @@
                             const bullet = this.bullets[j];
                             const bulletDist = Math.sqrt((bullet.x - enemy.x) ** 2 + (bullet.y - enemy.y) ** 2);
                             if (bulletDist < bullet.radius + enemy.radius) {
-                                if (enemy.type === 'rhombus' && enemy.invulnerable) continue;
+                                if ((enemy.spawnShieldUntil && Date.now() < enemy.spawnShieldUntil) || (enemy.type === 'rhombus' && enemy.invulnerable)) continue;
                                 this.bullets.splice(j, 1);
                                 if (!enemy.takeDamage(50, this.effects, this.score, this.ctx, this.audio)) {
                                     this.effects.createExplosion(enemy.x, enemy.y, enemy.type, enemy.radius);
+                                    if (enemy.type === 'rhombus') {
+                                        this.spawnTrianglesAround(enemy.x, enemy.y);
+                                    }
                                     this.enemies.splice(i, 1);
                                     this.score += enemy.points;
                                     this.enemiesKilled++;
@@ -2171,9 +2194,12 @@
                         for (let j = this.effects.effects.length - 1; j >= 0; j--) {
                             const effect = this.effects.effects[j];
                             if (effect.type === 'railgunBeam' && effect.intersectsEnemy(enemy)) {
-                                if (enemy.type === 'rhombus' && enemy.invulnerable) continue;
+                                if ((enemy.spawnShieldUntil && Date.now() < enemy.spawnShieldUntil) || (enemy.type === 'rhombus' && enemy.invulnerable)) continue;
                                 if (!enemy.takeDamage(effect.damage, this.effects, this.score, this.ctx, this.audio)) {
                                     this.effects.createExplosion(enemy.x, enemy.y, enemy.type, enemy.radius);
+                                    if (enemy.type === 'rhombus') {
+                                        this.spawnTrianglesAround(enemy.x, enemy.y);
+                                    }
                                     this.enemies.splice(i, 1);
                                     this.score += enemy.points;
                                     this.enemiesKilled++;


### PR DESCRIPTION
Implement Rhombus death to spawn 3 temporarily invulnerable Triangle enemies.

---
<a href="https://cursor.com/background-agent?bcId=bc-74993d7c-5e3e-43fb-853d-713c7f58a847">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-74993d7c-5e3e-43fb-853d-713c7f58a847">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

